### PR TITLE
fixed bug where double quotes are converted to single quotes

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -27,7 +27,7 @@ var sql = {
 		val = val.replace(/[\"\']/g, function(s) {
 			switch(s) {
 				case "\'": return "''";
-				case '\"': return "''";
+				case '\"': return '""';
 				default: return " ";
 			}
 		});


### PR DESCRIPTION
Hi Kyle, I noticed that double quotes were getting converted to single quotes in the sql.escape function. I am using the adapter to save HTML code with javascript on the page. I need double and single quotes to be preserved. This _should_ do the trick. Thoughts?